### PR TITLE
Add progress seed to process_wait_all() idle callbacks

### DIFF
--- a/cmake/process/linux/process_start_Linux.cmake
+++ b/cmake/process/linux/process_start_Linux.cmake
@@ -14,6 +14,8 @@ function(process_start_Linux process_handle)
   map_tryget(${process_start_info} command_arguments)
   ans(command_arguments)
 
+  map_tryget(${process_start_info} working_directory)
+  ans(working_directory)
 
   command_line_args_combine(${command_arguments})
   ans(command_arguments_string)
@@ -30,14 +32,14 @@ function(process_start_Linux process_handle)
   file_make_temporary("")
   ans(pid_out)
 
-  process_chanage_state(${process_handle} starting)
+  process_handle_change_state(${process_handle} starting)
   # create a temporary shell script 
   # which starts bash with the specified command 
   # output of the command is stored in stdout file 
   # error of the command is stored in stderr file 
   # return_code is stored in return_code file 
   # and the created process id is stored in pid_out
-  shell_tmp_script("( bash -c \"${command_string} > ${stdout} 2> ${stderr}\" ; echo $? > ${return_code}) & echo $! > ${pid_out}")
+  shell_tmp_script("( bash -c \"(cd ${working_directory}; ${command_string} > ${stdout} 2> ${stderr})\" ; echo $? > ${return_code}) & echo $! > ${pid_out}")
   ans(script)
   ## execute the script in bash with nohup 
   ## which causes the script to run detached from process
@@ -57,7 +59,7 @@ function(process_start_Linux process_handle)
 
   map_set(${process_handle} pid "${pid}")
 
-  process_chanage_state(${process_handle} running)
+  process_handle_change_state(${process_handle} running)
 
 
   ## set output of process


### PR DESCRIPTION
This way it's easy to print progress status based on that seed. It's not a real progress value, but a seed to be used to generate output.

I'm using it to generate dynamic ellipsis output with `\r` on the boost-biicode scripts.